### PR TITLE
Truncate desired size of node images when allocating pixel memory 

### DIFF
--- a/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
+++ b/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
@@ -181,7 +181,7 @@ bool FNodeDocsGenerator::GenerateNodeImage(UEdGraphNode* Node, FNodeProcessingSt
 		ReadPixelFlags.SetLinearToGamma(true); // @TODO: is this gamma correction, or something else?
 
 		PixelData = MakeUnique<TImagePixelData<FColor>>(FIntPoint((int32) Desired.X, (int32) Desired.Y));
-		PixelData->Pixels.SetNumUninitialized(Desired.X * Desired.Y);
+		PixelData->Pixels.SetNumUninitialized((int32) Desired.X * (int32) Desired.Y);
 
 		if (RTResource->ReadPixelsPtr(PixelData->Pixels.GetData(), ReadPixelFlags, Rect) == false)
 		{


### PR DESCRIPTION
On UE5, some of our nodes generated DesiredSizes that were not integer numbers.
This PR discards the decimal portion of the desired size, to match the other sizes we're using when saving out images - the decimal portion was causing us to ask for more pixels from an image than actually existed, leading to image output errors. 