### PR TITLE
Fixes a crash when processing Animation Blueprints

### DIFF
--- a/Source/KantanDocGen/KantanDocGen.Build.cs
+++ b/Source/KantanDocGen/KantanDocGen.Build.cs
@@ -19,6 +19,7 @@ public class KantanDocGen : ModuleRules
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "../../ThirdParty/variant/include"));
 		PublicDependencyModuleNames.AddRange(
             new string[] {
+	            "AnimGraph",
                 "Core",
                 "CoreUObject",
                 "Engine",

--- a/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
+++ b/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
@@ -5,6 +5,8 @@
 // Copyright (C) 2016-2017 Cameron Angus. All Rights Reserved.
 
 #include "NodeDocsGenerator.h"
+
+#include "AnimGraphNode_Base.h"
 #include "Async/Async.h"
 #include "BlueprintActionDatabase.h"
 #include "BlueprintBoundNodeSpawner.h"
@@ -933,6 +935,7 @@ bool FNodeDocsGenerator::IsSpawnerDocumentable(UBlueprintNodeSpawner* Spawner, b
 	static const TSubclassOf<UK2Node> ExcludedNodeClasses[] = {
 		UK2Node_DynamicCast::StaticClass(),
 		UK2Node_Message::StaticClass(),
+		UAnimGraphNode_Base::StaticClass(),
 	};
 
 	// Function spawners for functions with any of the following metadata tags will also be excluded


### PR DESCRIPTION
Currently the tool is unable to process Animation Blueprints and crashes the whole engine when reaching `NodeDocsGenerator.cpp:80`

`auto NodeInst = Spawner->Invoke(Graph.Get(), IBlueprintNodeBinder::FBindingSet {}, FVector2D(0, 0));`

Steps to reproduce:

- Have an ABP in the project with nodes and comments.