### PR TITLE
Fix up JSON parsing, added additional errors and logging support for NPM commands

### DIFF
--- a/Source/KantanDocGen/Private/DocGenTaskProcessor.cpp
+++ b/Source/KantanDocGen/Private/DocGenTaskProcessor.cpp
@@ -290,6 +290,7 @@ void FDocGenTaskProcessor::ProcessTask(TSharedPtr<FDocGenTask> InTask)
 		// GEditor->PlayEditorSound(CompileSuccessSound);
 		return;
 	}
+	UE_LOG(LogKantanDocGen, Log, TEXT("Created %i nodes to document!"), SuccessfulNodeCount)
 
 	// Game thread: DocGen.GT_Finalize()
 	auto FinalizeResult = Async(EAsyncExecution::TaskGraphMainThread, [GameThread_FinalizeDocs, IntermediateDir]() {
@@ -331,14 +332,14 @@ void FDocGenTaskProcessor::ProcessTask(TSharedPtr<FDocGenTask> InTask)
 
 	if (TransformationResult != EIntermediateProcessingResult::Success)
 	{
-		UE_LOG(LogKantanDocGen, Error, TEXT("Failed to transform xml to html!"));
-
 		auto Msg = FText::Format(LOCTEXT("DocConversionFailed", "Doc gen failed - {0}"),
 								 TransformationResult == EIntermediateProcessingResult::DiskWriteFailure
 									 ? LOCTEXT("CouldNotWriteToOutput",
 											   "Could not write output, please clear output directory or "
 											   "enable 'Clean Output Directory' option")
 									 : LOCTEXT("GenericTransformationFailure", "Conversion failure"));
+
+		UE_LOG(LogKantanDocGen, Error, TEXT("Failed to transform xml to html! Error: %s"), *Msg.ToString());
 		Async(EAsyncExecution::TaskGraphMainThread, [this, Msg] {
 			Current->Task->NotifySetText(Msg);
 			Current->Task->NotifySetCompletionState(SNotificationItem::CS_Fail);

--- a/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
+++ b/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
@@ -892,7 +892,7 @@ bool FNodeDocsGenerator::GenerateNodeDocTree(UK2Node* Node, FNodeProcessingState
 	}
 	else
 	{
-		UE_LOG(LogKantanDocGen, Warning, TEXT("[KantanDocGen] Cannot get type for node %s "), *NodeFullTitle);
+		UE_LOG(LogKantanDocGen, Error, TEXT("[KantanDocGen] Cannot get type for node %s "), *NodeFullTitle);
 	}
 	auto InputNode = NodeDocFile->AppendChild("inputs");
 

--- a/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.h
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.h
@@ -24,6 +24,7 @@ class DocGenMdxOutputProcessor : public IDocGenOutputProcessor
 	void CopyJsonField(const FString& FieldName, TSharedPtr<FJsonObject> ParsedNode, TSharedPtr<FJsonObject> OutNode);
 	TSharedPtr<FJsonObject> InitializeMainOutputFromIndex(TSharedPtr<FJsonObject> ParsedIndex);
 	EIntermediateProcessingResult ConvertJsonToMdx(FString IntermediateDir);
+	EIntermediateProcessingResult RunNPMCommand(const FString& Command, const FString& PackageJsonPath) const;
 	EIntermediateProcessingResult ConvertMdxToHtml(FString IntermediateDir, FString OutputDir);
 	FFilePath TemplatePath;
 	FDirectoryPath BinaryPath;
@@ -51,7 +52,8 @@ public:
 												   FString const& OutputDir,
 												   TSharedPtr<FJsonObject> ConsolidatedOutput);
 
-	TOptional<TArray<FString>> GetNamesFromIndexFile(const FString& NameType, TSharedPtr<FJsonObject> ParsedIndex);
+	TOptional<TArray<FString>> GetNamesFromIndexFile(const FString& NameType, const FString& ChildNameType,
+													 TSharedPtr<FJsonObject> ParsedIndex);
 
 	TSharedPtr<FJsonObject> LoadFileToJson(FString const& FilePath);
 };


### PR DESCRIPTION
- When transformation fails, it now returns the error message as well.
- Not finding a node type throws an error, otherwise doc generation will fail later on.
- New `RunNPMCommand` method to call node.exe instead of npm.cmd, so that we can pipe output and log it out to surface errors more easily.
- Fixed issue where `GetNamesFromIndexFile` can fail if the JSON index only had a single entry instead of an expected array.
- Added additional error messages when consolidation fails, to report which part failed.