### PR TITLE
fix: added support for nodejs paths with spaces

### DIFF
--- a/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
@@ -351,7 +351,8 @@ EIntermediateProcessingResult DocGenMdxOutputProcessor::RunNPMCommand(const FStr
 	// We run this JS code to simulate npm.cmd, but allow us to read the output and catch errors
 	FString JsCode = FString::Printf(TEXT("try { "
 										  "  process.env['PATH'] += path.delimiter + '%s';"
-										  "  const o = require('child_process').execSync('\"%s\\\\npm.cmd\" %s'); "
+										  "  const commandToRun = \`\"%s\\\\npm.cmd\" %s\`;"
+										  "  const o = require('child_process').execSync(commandToRun); "
 										  "  console.log(o.toString()); "
 										  "} catch (e) { "
 										  "  console.error(e.stdout?.toString() || e.message); "

--- a/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
@@ -351,7 +351,7 @@ EIntermediateProcessingResult DocGenMdxOutputProcessor::RunNPMCommand(const FStr
 	// We run this JS code to simulate npm.cmd, but allow us to read the output and catch errors
 	FString JsCode = FString::Printf(TEXT("try { "
 										  "  process.env['PATH'] += path.delimiter + '%s';"
-										  "  const o = require('child_process').execSync('%s\\\\npm.cmd %s'); "
+										  "  const o = require('child_process').execSync('\"%s\\\\npm.cmd\" %s'); "
 										  "  console.log(o.toString()); "
 										  "} catch (e) { "
 										  "  console.error(e.stdout?.toString() || e.message); "

--- a/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
@@ -351,7 +351,7 @@ EIntermediateProcessingResult DocGenMdxOutputProcessor::RunNPMCommand(const FStr
 	// We run this JS code to simulate npm.cmd, but allow us to read the output and catch errors
 	FString JsCode = FString::Printf(TEXT("try { "
 										  "  process.env['PATH'] += path.delimiter + '%s';"
-										  "  const commandToRun = \`\"%s\\\\npm.cmd\" %s\`;"
+										  "  const commandToRun = `\"%s\\\\npm.cmd\" %s`;"
 										  "  const o = require('child_process').execSync(commandToRun); "
 										  "  console.log(o.toString()); "
 										  "} catch (e) { "

--- a/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
@@ -347,6 +347,11 @@ EIntermediateProcessingResult DocGenMdxOutputProcessor::RunNPMCommand(const FStr
 {
 	FString NPMDirectory = FPaths::GetPath(NpmExecutablePath.FilePath);
 	FString NodeExe = FString::Printf(TEXT("%s\\node.exe"), *NPMDirectory);
+
+	FPaths::MakePlatformFilename(NPMDirectory);
+
+	FString JsEscapedNPMDirectory = NPMDirectory.Replace(TEXT("\\"), TEXT("\\\\"));
+
 	FString EscapedNPMDirectory = NPMDirectory.ReplaceCharWithEscapedChar();
 	// We run this JS code to simulate npm.cmd, but allow us to read the output and catch errors
 	FString JsCode = FString::Printf(TEXT("try { "
@@ -358,7 +363,7 @@ EIntermediateProcessingResult DocGenMdxOutputProcessor::RunNPMCommand(const FStr
 										  "  console.error(e.stdout?.toString() || e.message); "
 										  "  process.exit(1); "
 										  "}"),
-									 *EscapedNPMDirectory, *EscapedNPMDirectory, *Command);
+									 *JsEscapedNPMDirectory, *JsEscapedNPMDirectory, *Command);
 	FString Args = FString::Printf(TEXT("-e \"%s\""), *JsCode);
 
 	void* ReadPipe = nullptr;

--- a/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenMdxOutputProcessor.cpp
@@ -346,24 +346,25 @@ EIntermediateProcessingResult DocGenMdxOutputProcessor::RunNPMCommand(const FStr
 																	  const FString& PackageJsonPath) const
 {
 	FString NPMDirectory = FPaths::GetPath(NpmExecutablePath.FilePath);
-	FString NodeExe = FString::Printf(TEXT("%s\\node.exe"), *NPMDirectory);
 
-	FPaths::MakePlatformFilename(NPMDirectory);
-
-	FString JsEscapedNPMDirectory = NPMDirectory.Replace(TEXT("\\"), TEXT("\\\\"));
+	FString NodeExe = FPaths::Combine(*NPMDirectory, TEXT("node.exe"));
+	FString NPMCMD = FPaths::Combine(*NPMDirectory, TEXT("npm.cmd"));
 
 	FString EscapedNPMDirectory = NPMDirectory.ReplaceCharWithEscapedChar();
+	FString EscapedNPMCMD = NPMCMD.ReplaceCharWithEscapedChar();
+
 	// We run this JS code to simulate npm.cmd, but allow us to read the output and catch errors
 	FString JsCode = FString::Printf(TEXT("try { "
 										  "  process.env['PATH'] += path.delimiter + '%s';"
-										  "  const commandToRun = `\"%s\\\\npm.cmd\" %s`;"
+										  "  const commandToRun = `\"\"%s\"\" %s`;"
 										  "  const o = require('child_process').execSync(commandToRun); "
 										  "  console.log(o.toString()); "
 										  "} catch (e) { "
 										  "  console.error(e.stdout?.toString() || e.message); "
 										  "  process.exit(1); "
 										  "}"),
-									 *JsEscapedNPMDirectory, *JsEscapedNPMDirectory, *Command);
+									 *EscapedNPMDirectory, *EscapedNPMCMD, *Command);
+
 	FString Args = FString::Printf(TEXT("-e \"%s\""), *JsCode);
 
 	void* ReadPipe = nullptr;


### PR DESCRIPTION
Added quotes around the nmp.cmd path to support paths with spaces