### PR TITLE
feat: decouple binary path from doc folder

### DIFF
--- a/Source/KantanDocGen/Private/OutputFormats/DocGenJsonOutputFormat.cpp
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenJsonOutputFormat.cpp
@@ -121,7 +121,12 @@ TSharedPtr<struct IDocGenOutputProcessor> UDocGenJsonOutputFactory::CreateInterm
 	{
 		RubyOverride = RubyPath;
 	}
-	return MakeShared<DocGenJsonOutputProcessor>(TemplateOverride, BinaryOverride, RubyOverride);
+	TOptional<FDirectoryPath> DocRootPathOverride;
+	if (bOverrideDocRootPath)
+	{
+		DocRootPathOverride = DocRootPath;
+	}
+	return MakeShared<DocGenJsonOutputProcessor>(TemplateOverride, BinaryOverride, RubyOverride, DocRootPathOverride);
 }
 
 FString UDocGenJsonOutputFactory::GetFormatIdentifier()
@@ -155,6 +160,14 @@ void UDocGenJsonOutputFactory::LoadSettings(const FDocGenOutputFormatFactorySett
 			bOverrideRubyPath = (Settings.SettingValues["overrideruby"] == "true");
 		}
 	}
+	if (Settings.SettingValues.Contains("docroot"))
+	{
+		DocRootPath.Path = Settings.SettingValues["docroot"];
+		if (Settings.SettingValues.Contains("overridedocroot"))
+		{
+			bOverrideDocRootPath = (Settings.SettingValues["overridedocroot"] == "true");
+		}
+	}
 }
 
 FDocGenOutputFormatFactorySettings UDocGenJsonOutputFactory::SaveSettings()
@@ -177,6 +190,12 @@ FDocGenOutputFormatFactorySettings UDocGenJsonOutputFactory::SaveSettings()
 		Settings.SettingValues.Add("overrideruby", "true");
 	}
 	Settings.SettingValues.Add("ruby", RubyPath.FilePath);
+
+	if (bOverrideDocRootPath)
+	{
+		Settings.SettingValues.Add("overridedocroot", "true");
+	}
+	Settings.SettingValues.Add("docroot", DocRootPath.Path);
 
 	Settings.FactoryClass = StaticClass();
 	return Settings;

--- a/Source/KantanDocGen/Private/OutputFormats/DocGenJsonOutputFormat.h
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenJsonOutputFormat.h
@@ -54,6 +54,12 @@ public:
 	FDirectoryPath BinaryPath;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
+	bool bOverrideDocRootPath = false;
+
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta = (EditCondition = "bOverrideDocRootPath"))
+	FDirectoryPath DocRootPath;
+
+	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	bool bOverrideRubyPath = false;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta = (EditCondition = "bOverrideRubyPath"))

--- a/Source/KantanDocGen/Private/OutputFormats/DocGenJsonOutputProcessor.h
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenJsonOutputProcessor.h
@@ -27,11 +27,12 @@ class DocGenJsonOutputProcessor : public IDocGenOutputProcessor
 	EIntermediateProcessingResult ConvertAdocToHTML(FString IntermediateDir, FString OutputDir);
 	FFilePath TemplatePath;
 	FDirectoryPath BinaryPath;
+	FDirectoryPath DocRootPath;
 	FFilePath RubyExecutablePath;
 
 public:
 	DocGenJsonOutputProcessor(TOptional<FFilePath> TemplatePathOverride, TOptional<FDirectoryPath> BinaryPathOverride,
-							  TOptional<FFilePath> RubyExecutablePathOverride);
+							  TOptional<FFilePath> RubyExecutablePathOverride, TOptional<FDirectoryPath> DocRootPathOverride);
 	virtual EIntermediateProcessingResult ProcessIntermediateDocs(FString const& IntermediateDir,
 																  FString const& OutputDir, FString const& DocTitle,
 																  bool bCleanOutput) override;


### PR DESCRIPTION
Binary path was previously used to determine some relative directories.
This PR aims to change that so that doc_root is used instead.