### PR TITLE
fix: Uninitialized UPROPERTY [GSCPP-2159]

### DIFF
--- a/Source/KantanDocGen/Private/OutputFormats/DocGenOutputFormatFactory.h
+++ b/Source/KantanDocGen/Private/OutputFormats/DocGenOutputFormatFactory.h
@@ -19,9 +19,9 @@ struct FDocGenOutputFormatFactorySettings
 	GENERATED_BODY()
 
 	UPROPERTY()
-	TMap<FString, FString> SettingValues;
+	TMap<FString, FString> SettingValues = {};
 	UPROPERTY()
-	UClass* FactoryClass;
+	UClass* FactoryClass = nullptr;
 };
 
 class KANTANDOCGEN_API IDocGenOutputFormatFactory


### PR DESCRIPTION
Clickup Link: https://app.clickup.com/t/9003015469/GSCPP-2159

The automated tests are failing when they spin up an editor instance to run gauntlet, due to uninitialized properties.

`LogClass: Error: ClassProperty FDocGenOutputFormatFactorySettings::FactoryClass is not initialized properly. Module:KantanDocGen File:Private/OutputFormats/DocGenOutputFormatFactory.h`